### PR TITLE
Improve `toolchain` Docker image (#55)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,16 +2,41 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "labels": ["enhancement", "k::dependencies"],
+  "separateMajorMinor": false,
   "packageRules": [
     {
-      "matchFileNames": ["biome.json"],
-      "addLabels": ["k::toolchain"]
+      "addLabels": ["docker"],
+      "matchFileNames": ["Dockerfile"]
     },
     {
-      "matchFileNames": ["Dockerfile"],
-      "addLabels": ["docker"]
+      "addLabels": ["python"],
+      "matchDepNames": ["library/python"]
+    },
+    {
+      "addLabels": ["k::toolchain"],
+      "matchFileNames": ["biome.json"]
+    },
+    {
+      "addLabels": ["ansible"],
+      "groupName": "ansible",
+      "matchFileNames": [
+        "ansible/pip.requirements.txt",
+        "ansible/ansible-galaxy.deps.yml"
+      ]
+    },
+    {
+      "addLabels": ["ansible"],
+      "groupName": "ansible",
+      "matchPackageNames": ["ansible", "library/python"],
+      "matchFileNames": ["Dockerfile"]
     }
   ],
+  "pip_requirements": {
+    "managerFilePatterns": ["ansible/pip.requirements.txt"]
+  },
+  "ansible-galaxy": {
+    "managerFilePatterns": ["ansible/ansible-galaxy.deps.yml"]
+  },
   "github-actions": {
     "addLabels": ["github_actions", "k::toolchain"]
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,37 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
-## main
+## [3.0.0] · 2025-12-10
+[3.0.0]: /../../tree/3.0.0
 
-[Diff](/../../compare/2.1.4...main)
+[Diff](/../../compare/2.1.4...3.0.0)
 
+### Added
+
+- [Vim] to use as the default editor inside the toolchain container.
+
+### Changed
+
+- Disable checks for newer [Deno] versions.
+- Use fixed versions for [pip] packages.
+
+### Upgraded
+
+- [Python] 3.13.11: <https://docs.python.org/3.13/whatsnew/changelog.html#python-3-13-11-final>
+- [Ansible] 11.12.0: <https://github.com/ansible-community/ansible-build-data/blob/11.12.0/11/CHANGELOG-v11.md#release-summary>
+- [Ansible] roles:
+    - [`instrumentisto.coreos-bootstrap`] 4.0.1: <https://github.com/instrumentisto/ansible-coreos-bootstrap/blob/main/CHANGELOG.md#401--2025-12-10>
+- [Ansible] collections:
+    - [`community.general`] 11.4.1: <https://github.com/ansible-collections/community.general/blob/11.4.1/CHANGELOG.md#v11-4-1>
+    - [`containers.podman`] 1.18.0: <https://github.com/containers/ansible-podman-collections/blob/1.18.0/CHANGELOG.rst#v1-18-0>
+    - [`hetzner.hcloud`] 6.0.0: <https://github.com/ansible-collections/hetzner.hcloud/releases/tag/6.0.0>
+    - [`kubernetes.core`] 6.2.0: <https://github.com/ansible-collections/kubernetes.core/blob/6.2.0/CHANGELOG.rst#v6-2-0>
+- [pip] packages:
+    - [`jmespath`] 1.0.1: <https://github.com/jmespath/jmespath.py/blob/develop/CHANGELOG.rst#101>
+    - [`hcloud`] 2.9.0: <https://github.com/hetznercloud/hcloud-python/blob/main/CHANGELOG.md#v290>
+    - [`kubernetes-validate`] 1.34.1: <https://github.com/willthames/kubernetes-validate/releases/tag/v1.34.1>
+    - [`kubernetes`] 34.1.0: <https://github.com/kubernetes-client/python/blob/master/CHANGELOG.md#v3410b1>
+    - [`netaddr`] 1.3.0: <https://netaddr.readthedocs.io/en/latest/changes.html#release-1-3-0>
 - [DigitalOcean CLI] 1.148.0: <https://github.com/digitalocean/doctl/releases/tag/v1.148.0>
 - [Kubernetes CLI] 1.34.3: <https://github.com/kubernetes/kubernetes/blob/f887a29fe220c1013ae09699bb301040beb5c86e/CHANGELOG/CHANGELOG-1.34.md#changelog-since-v1342>
 
@@ -303,18 +330,24 @@ All user visible changes to this project will be documented in this file. This p
 - [Jsonnet Bundler] 0.6.0: <https://github.com/jsonnet-bundler/jsonnet-bundler/releases/tag/v0.6.0>
 - [Kubernetes CLI] 1.34.1: <https://github.com/kubernetes/kubernetes/blob/70af7708fcc585a717f9208f83a4351585440bab/CHANGELOG/CHANGELOG-1.34.md#changelog-since-v1340>
 - [Python] 3.13.7: <https://docs.python.org/3.13/whatsnew/changelog.html#python-3-13-7-final>
-- [pip] packages: `jmespath`, `hcloud`, `kubernetes-validate`, `kubernetes`, `netaddr`
+- [pip] packages: [`jmespath`], [`hcloud`], [`kubernetes-validate`], [`kubernetes`], [`netaddr`]
 - [Terraform] 1.13.3: <https://github.com/hashicorp/terraform/releases/tag/v1.13.3>
 
 
 
 
+[`instrumentisto.coreos-bootstrap`]: https://github.com/instrumentisto/ansible-coreos-bootstrap
 [`community.digitalocean`]: https://galaxy.ansible.com/ui/repo/published/community/digitalocean
 [`community.general`]: https://galaxy.ansible.com/ui/repo/published/community/general
 [`containers.podman`]: https://galaxy.ansible.com/ui/repo/published/containers/podman
 [`hetzner.hcloud`]: https://galaxy.ansible.com/ui/repo/published/hetzner/hcloud
 [`kubernetes.core`]: https://galaxy.ansible.com/ui/repo/published/kubernetes/core
 [`vultr.cloud`]: https://galaxy.ansible.com/ui/repo/published/vultr/cloud
+[`hcloud`]: https://pypi.org/project/hcloud
+[`jmespath`]: https://pypi.org/project/jmespath
+[`kubernetes-validate`]: https://pypi.org/project/kubernetes-validate
+[`kubernetes`]: https://pypi.org/project/kubernetes
+[`netaddr`]: https://pypi.org/project/netaddr
 [Ansible]: https://redhat.com/ansible-collaborative
 [Biome]: https://biomejs.dev
 [Butane]: https://coreos.github.io/butane
@@ -330,3 +363,4 @@ All user visible changes to this project will be documented in this file. This p
 [Python]: https://python.org
 [Semantic Versioning 2.0.0]: https://semver.org
 [Terraform]: https://hashicorp.com/products/terraform
+[Vim]: https://www.vim.org

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-ARG python_ver=3.13.7
+ARG python_ver=3.13.11
 # https://hub.docker.com/_/python/
 FROM python:${python_ver}-slim-trixie
 
-ARG image_ver=2.1.4
-ARG ansible_ver=9.13.0
+ARG image_ver=3.0.0
+ARG ansible_ver=11.12.0
 ARG biome_ver=2.3.8
 ARG butane_ver=0.25.1
 ARG deno_ver=2.5.6
@@ -18,6 +18,12 @@ ARG terraform_ver=1.14.1
 # Indication that the current context is inside this toolchain container.
 ENV TOOLCHAIN=1
 
+# Set Vim as the default editor explicitly.
+ENV EDITOR=vim
+
+# Disable checks for newer Deno versions.
+ENV DENO_NO_UPDATE_CHECK=1
+
 # Prepare project directory.
 RUN mkdir -p /app/
 WORKDIR /app/
@@ -29,6 +35,7 @@ RUN apt-get update \
             ca-certificates \
             curl \
             git \
+            vim \
             libvirt-clients \
             make \
             rsync \

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Lifesaving tools used by Instrumentisto Team.
 
 ## Supported tags and respective `Dockerfile` links
 
-- [`2.1.4`, `2.1`, `2`, `latest`][d1]
+- [`3.0.0`, `3.0`, `3`, `latest`][d1]
 
 
 

--- a/ansible/ansible-galaxy.deps.yml
+++ b/ansible/ansible-galaxy.deps.yml
@@ -3,7 +3,7 @@
 roles:
   - name: instrumentisto.coreos-bootstrap
     src: git+https://github.com/instrumentisto/ansible-coreos-bootstrap
-    version: 4.0.0
+    version: 4.0.1
 
 # Check minimal Ansible version requirements before upgrading collections.
 collections:
@@ -12,16 +12,16 @@ collections:
     version: 1.27.0
   # https://galaxy.ansible.com/ui/repo/published/community/general
   - name: community.general
-    version: 10.5.0
+    version: 11.4.1
   # https://galaxy.ansible.com/ui/repo/published/containers/podman
   - name: containers.podman
-    version: 1.16.3
+    version: 1.18.0
   # https://galaxy.ansible.com/ui/repo/published/hetzner/hcloud
   - name: hetzner.hcloud
-    version: 4.3.0
+    version: 6.0.0
   # https://galaxy.ansible.com/ui/repo/published/kubernetes/core
   - name: kubernetes.core
-    version: 5.2.0
+    version: 6.2.0
   # https://galaxy.ansible.com/ui/repo/published/vultr/cloud
   - name: vultr.cloud
     version: 1.13.0

--- a/ansible/pip.requirements.txt
+++ b/ansible/pip.requirements.txt
@@ -1,5 +1,5 @@
-jmespath
-hcloud
-kubernetes-validate
-kubernetes
-netaddr
+jmespath==1.0.1
+hcloud==2.9.0
+kubernetes-validate==1.34.1
+kubernetes==34.1.0
+netaddr==1.3.0


### PR DESCRIPTION
FCM
```
Improve `toolchain` Docker image (#55)

- add Vim to use as the default editor inside the `toolchain` container
- disable checks for newer Deno versions
- use fixed versions for `pip` packages
- upgrade Python to 3.13.11 version
- upgrade Ansible to 11.12.0 version
- upgrade `instrumentisto.coreos-bootstrap` role to 4.0.1 version
- upgrade `community.general` collection to 11.4.1 version
- upgrade `containers.podman` collection to 1.18.0 version
- upgrade `hetzner.hcloud` collection to 6.0.0 version
- upgrade `kubernetes.core` collection to 6.2.0 version
- upgrade `jmespath` package to 1.0.1 version
- upgrade `hcloud` package to 2.9.0 version
- upgrade `kubernetes-validate` package to 1.34.1 version
- upgrade `kubernetes` package to 34.1.0 version
- upgrade `netaddr` package to 1.3.0 version

Additionally:
- group Ansible packages and dependencies into a single @renovate pull request
- do not separate major and minor versions when @renovate upgrades dependencies
```